### PR TITLE
Saved queries

### DIFF
--- a/crossbot/commands/query.py
+++ b/crossbot/commands/query.py
@@ -1,0 +1,45 @@
+from crossbot.commands import sql
+import sqlite3
+from datetime import datetime
+import crossbot
+from multiprocessing import Pool, TimeoutError
+
+def init(client):
+    parser = client.parser.subparsers.add_parser('query', help='Run a saved query')
+    parser.set_defaults(command=query)
+
+    parser.add_argument('name', help='Stored query name to run')
+    parser.add_argument('--save', action='store_true', help='Create or overwrite a stored query')
+    parser.add_argument('params', nargs='*', help='Parameters for the stored query or, if saving, the query itself, with question marks for parameters')
+
+def query(client, request):
+    if request.args.save:
+        cmd = sql.format_sql_cmd(" ".join(request.args.params))
+        with sqlite3.connect(crossbot.db_path) as con:
+            query = '''
+            INSERT OR REPLACE INTO query_shorthands(name, command, userid, timestamp)
+            VALUES(?, ?, ?, ?)
+            '''
+            con.execute(query, (request.args.name, cmd, request.userid, datetime.now()))
+        request.reply("Saved new query `{}` from {}".format(request.args.name, client.user(request.userid)))
+    else:
+        params = [sql.format_sql_cmd(param) for param in request.args.params]
+        with sqlite3.connect(crossbot.db_path) as con:
+            query = '''
+            SELECT command FROM query_shorthands
+            WHERE name = ?
+            '''
+            result = con.execute(query, (request.args.name,)).fetchone()
+        if result:
+            cmd, = result
+            try:
+                with Pool() as pool:
+                    print(cmd)
+                    result = pool.apply_async(sql.do_sql, [cmd] + params).get(1)
+            except TimeoutError:
+                result = "you cant dos me even with saved queries, incident reported"
+
+            result = sql.format_sql_result(result, client)
+            request.reply(result)
+        else:
+            request.reply("No known command `{}`".format(request.args.name))

--- a/scripts/init_db.sql
+++ b/scripts/init_db.sql
@@ -4,7 +4,7 @@ crossword_time(
   userid   TEXT NOT NULL,
   date     INTEGER NOT NULL,
   seconds  INTEGER NOT NULL,
-  timestamp DATETIME;
+  timestamp DATETIME,
   UNIQUE(userid, date)
 );
 
@@ -13,7 +13,7 @@ mini_crossword_time(
   userid   TEXT NOT NULL,
   date     INTEGER NOT NULL,
   seconds  INTEGER NOT NULL,
-  timestamp DATETIME;
+  timestamp DATETIME,
   UNIQUE(userid, date)
 );
 
@@ -22,7 +22,7 @@ easy_sudoku_time(
   userid   TEXT NOT NULL,
   date     INTEGER NOT NULL,
   seconds  INTEGER NOT NULL,
-  timestamp DATETIME;
+  timestamp DATETIME,
   UNIQUE(userid, date)
 );
 
@@ -31,6 +31,6 @@ query_shorthands(
   name      TEXT NOT NULL,
   command   TEXT NOT NULL,
   userid    TEXT NOT NULL,
-  timestamp TEXT NOT NULL;
+  timestamp TEXT NOT NULL,
   UNIQUE(name)
 );

--- a/scripts/init_db.sql
+++ b/scripts/init_db.sql
@@ -25,3 +25,12 @@ easy_sudoku_time(
   timestamp DATETIME;
   UNIQUE(userid, date)
 );
+
+CREATE TABLE IF NOT EXISTS
+query_shorthands(
+  name      TEXT NOT NULL,
+  command   TEXT NOT NULL,
+  userid    TEXT NOT NULL,
+  timestamp TEXT NOT NULL;
+  UNIQUE(name)
+);


### PR DESCRIPTION
Add and run saved queries.

+ `query --save NAME SQL` saves or overwrites the query `NAME` with to mean the SQL command `SQL`, with question marks standing for arguments
+ `query NAME ARGS ...` runs the query `NAME` with arguments `ARGS` substituted in

Queries are saved in the `query_shorthands` table. Tested and works locally.