### PR TITLE
Added a statistical model

### DIFF
--- a/crossbot.stan
+++ b/crossbot.stan
@@ -13,9 +13,9 @@ data {
 
 transformed data {
     vector[Ss] is_sat;
-    for (j in 1:Ss) is_sat[j] = (dows[j] == 7 ? 1.0 : 0.0);
-
     real<lower=0> corrected_secs[Ss];
+
+    for (j in 1:Ss) is_sat[j] = (dows[j] == 7 ? 1.0 : 0.0);
     for (j in 1:Ss) corrected_secs[j] = (secs[j] < 0 ? 300 : secs[j]);
 }
 

--- a/crossbot.stan
+++ b/crossbot.stan
@@ -1,0 +1,55 @@
+data {
+    int<lower=0> Ss; // number of seconds
+    int<lower=0> Us; // number of users
+    int<lower=0> Ds; // number of dates
+
+    real<lower=0> secs[Ss];
+
+    int<lower=1,upper=Us> uids[Ss];
+    int<lower=1,upper=7> dows[Ss];
+    int<lower=1,upper=Ds> dates[Ss];
+    real ago[Ss];
+}
+
+parameters {
+    real<lower=0> mu;
+    real<lower=0> sigma;
+
+    real skill_effect[Us];
+    real<lower=0> skill_dev;
+
+    real date_effect[Ds];
+    real<lower=0> date_dev;
+
+    real sat_effect;
+
+    real improvement_rate[Us];
+    real improvement_dev;
+}
+
+model {
+    // Priors
+    skill_effect ~ normal(0, skill_dev);
+    date_effect ~ normal(0, date_dev);
+    improvement_rate ~ normal(0, improvement_dev);
+
+    // Model
+    for (j in 1:Ss)
+    secs[j] ~ lognormal(mu + skill_effect[uids[j]] +
+                        (improvement_rate[uids[j]] * ago[j]) +
+                        date_effect[dates[j]] +
+                        (dows[j] == 7 ? sat_effect : 0),
+                        sigma);
+}
+
+generated quantities {
+    real avg_time;
+    real avg_skill[Us];
+    real avg_date[Ds];
+    real avg_sat;
+
+    avg_time = exp(mu);
+    for (j in 1:Us) avg_skill[j] = exp(skill_effect[j]);
+    for (j in 1:Ds) avg_date[j] = exp(date_effect[j]);
+    avg_sat = exp(sat_effect);
+}

--- a/model.py
+++ b/model.py
@@ -6,6 +6,8 @@ from datetime import datetime, timedelta
 import matplotlib, matplotlib.dates, matplotlib.figure, matplotlib.ticker
 from scipy.signal import savgol_filter
 import matplotlib.backends.backend_agg as agg
+import bisect
+import math
 
 def index(l):
     x = list(sorted(set(l)))
@@ -16,19 +18,20 @@ def unindex(l, i):
 
 def data():
     with sqlite3.connect("crossbot.db") as cursor:
-         uids, dates, dows, secs = zip(*cursor.execute("select userid, date, strftime('%w', date), seconds from mini_crossword_time"))
-         return { 'uids': uids, 'dates': dates, 'dows': dows, 'secs': secs }
+         uids, dates, dows, secs, ts = zip(*cursor.execute("select userid, date, strftime('%w', date), seconds, timestamp from mini_crossword_time"))
+         return { 'uids': uids, 'dates': dates, 'dows': dows, 'secs': secs, 'ts': ts }
 
-def ago(uids, dates):
+def nth(uids, dates, ts):
     uid_dates = { the_uid: sorted([date for uid, date in zip(uids, dates) if uid == the_uid])
                  for the_uid in set(uids)}
-    return [ len(uid_dates[uid]) - uid_dates[uid].index(date) for uid, date in zip(uids, dates) ]
+    return [ bisect.bisect(uid_dates[uid], ts.split(" ")[0] if ts else date) + 1
+             for uid, date, ts in zip(uids, dates, ts) ]
 
-def munge_data(uids, dates, dows, secs):
+def munge_data(uids, dates, dows, secs, ts):
     return {
         'uids': index(uids),
         'dates': index(dates),
-        'ago': map(float, ago(uids, dates)),
+        'nth': nth(uids, dates, ts),
         'dows': [int(dow) + 1 for dow in dows],
         'secs': secs,
         'Us': len(set(uids)),
@@ -38,7 +41,10 @@ def munge_data(uids, dates, dows, secs):
 
 def fit(data):
     sm = pystan.StanModel(file="crossbot.stan")
-    fm = sm.sampling(data=munge_data(**data), pars=['avg_time', 'avg_sat', 'avg_skill', 'avg_date', 'skill_dev', 'date_dev', 'sigma', 'improvement_rate'], iter=1000, chains=4)
+    fm = sm.sampling(data=munge_data(**data), pars=[
+        'avg_time', 'avg_sat', 'avg_skill', 'avg_date', 'skill_dev', 'date_dev', 'sigma',
+        'beginner_gain', 'beginner_decay',
+    ], iter=1000, chains=4)
     return fm
 
 def drange(data):
@@ -46,11 +52,8 @@ def drange(data):
     mu = data.mean()
     return mu, mu - data[len(data) // 4], data[len(data) * 3 // 4] - mu
 
-def pi(n, l):
-    return map(lambda x: x[n], l)
-
 def extract_model(fm):
-    params = fm.extract(['avg_time', 'avg_sat', 'avg_skill', 'avg_date', 'skill_dev', 'date_dev', 'sigma', 'improvement_rate'])
+    params = fm.extract()
     
     dates = []
     for i, multiplier in enumerate(params["avg_date"].transpose()):
@@ -59,19 +62,87 @@ def extract_model(fm):
         dates.append({'date': date, 'difficulty': mult_mean, 'difficulty_25': mult_25, 'difficulty_75': mult_75})
 
     users = []
-    for i, (multiplier, rate) in enumerate(zip(params["avg_skill"].transpose(), params["improvement_rate"].transpose())):
+    for i, multiplier in enumerate(params["avg_skill"].transpose()):
         uid = unindex(DATA['uids'], i + 1)
         mult_mean, mult_25, mult_75 = drange(multiplier)
-        rate_mean, rate_25, rate_75 = drange(rate)
-        users.append({ 'uid': uid, 'skill': mult_mean, 'skill_25': mult_25, 'skill_75': mult_75,
-                       'rate': rate_mean, 'rate_25': rate_25, 'rate_75': rate_75 })
+        #rate_mean, rate_25, rate_75 = drange(rate)
+        users.append({ 'uid': uid,
+                       'skill': mult_mean, 'skill_25': mult_25, 'skill_75': mult_75,
+                       #'rate': rate_mean, 'rate_25': rate_25, 'rate_75': rate_75,
+        })
 
+    bgain_mean, bgain_25, bgain_75 = drange(params['beginner_gain'])
+    bdecay_mean, bdecay_25, bdecay_75 = drange(params['beginner_decay'])
     time_mean, time_25, time_75 = drange(params['avg_time'])
     satmult_mean, satmult_25, satmult_75 = drange(params['avg_sat'])
     return { 'dates': dates, 'users': users, 'time': time_mean, 'time_25': time_25, 'time_75': time_75,
              'satmult': satmult_mean, 'satmult_25': satmult_25, 'satmult_75': satmult_75,
+             'bgain': bgain_mean, 'bgain_25': bgain_25, 'bgain_75': bgain_75,
+             'bdecay': bdecay_mean, 'bdecay_25': bdecay_25, 'bdecay_75': bdecay_75,
              'skill_dev': params['skill_dev'].mean(), 'date_dev': params['date_dev'].mean(), 'sigma': params['sigma'].mean(),
     }
+
+MODEL_SQL = """
+CREATE TABLE IF NOT EXISTS model_users (
+  uid text not null primary key,
+  skill real not null,
+  skill_25 real not null,
+  skill_75 real not null,
+);
+
+CREATE TABLE IF NOT EXISTS model_dates (
+  date integer not null primary key,
+  difficulty real not null,
+  difficulty_25 real not null,
+  difficulty_75 real not null,
+);
+
+CREATE TABLE IF NOT EXISTS model_params (
+  time real, time_25 real, time_75 real,
+  satmult real, satmult_25 real, satmult_75 real,
+  skill_dev real, date_dev real, sigma real
+);
+"""
+
+def save(MODEL):
+    with sqlite3.connect("crossbot.db") as cursor:
+        cursor.execute("drop table if exists model_users")
+        cursor.execute("drop table if exists model_dates")
+        cursor.execute("drop table if exists model_params")
+        cursor.execute(MODEL_SQL)
+
+        cursor.executemany(
+            "insert into model_user(uid, skill, skill_25, skill_75) values(?,?,?,?)",
+            [(user["uid"], user["skill"], user["skill_25"], user["skill_75"])
+             for user in model["users"]])
+
+        cursor.execute(
+            "insert into model_dates(date, difficulty, difficulty_25, difficulty_75) values(?,?,?,?)",
+            [(date["date"], date["difficulty"], date["difficulty_25"], date["difficulty_75"])
+             for dates in model["dates"]])
+
+        cursor.execute(
+            "insert into model_params(time, time_25, time_75, satmult, satmult_25, satmult_75, skill_dev, date_dev, sigma) values(?,?,?,?,?,?,?,?,?)",
+            (model["time"], model["time_25"], model["time_75"],
+             model["satmult"], model["satmult_25"], model["satmult_75"],
+             model["skill_dev"], model["date_dev"], model["sigma"]))
+
+def residuals(data, model):
+    from math import log, exp
+    for uid, date, dow, sec, n \
+        in zip(data["uids"], data["dates"], data["dows"], data["secs"],
+               nth(data["uids"], data["dates"], data["ts"])):
+        user = [rec for rec in model["users"] if rec["uid"] == uid][0]
+        day = [rec for rec in model["dates"] if rec["date"] == date][0]
+
+        # Quick and dirty
+        mean = log(model["time"]) \
+            + log(user["skill"]) \
+            + log(day["difficulty"]) \
+            + log(model["satmult"] if dow == '6' else 1) \
+            + model['bgain'] * exp(-n / model['bdecay']) \
+
+        yield (log(sec if sec >= 0 else 300) - mean) / model["sigma"]
 
 def summarize(model, nameuser=lambda x: x):
     for date in model['dates']:
@@ -80,16 +151,17 @@ def summarize(model, nameuser=lambda x: x):
 
     for user in sorted(model['users'], key=lambda x: x['skill']):
         name = nameuser(user['uid'])
-        print("{0:>20}: {1[skill]: 6.3f} (-{1[skill_25]: 4.3f} {1[skill_75]:=+6.3f}) {1[rate]:=+9.05f} t".format(name, user))
+        print(("{0:>20}: {1[skill]: 6.3f} (-{1[skill_25]: 4.3f} {1[skill_75]:=+6.3f})"
+               #+ " {1[rate]:=+9.05f} t"
+        ).format(name, user))
 
 def plot_dates(model):
-    field = lambda f: [x[f] for x in model['dates'] if x['date'][:4] >= '2017']
-
+    field = lambda f: [x[f] for x in model['dates'] if x['date'] >= '2017']
     fig = matplotlib.figure.Figure(figsize=(11, 8.5))
     ax = fig.add_subplot(1, 1, 1)
     ax.xaxis_date(None)
     ax.set_yscale('log')
-    ax.set_yticks([.4, .5, .6, .7, .85, 1, 1.2, 1.4, 1.66, 2, 2.5, 3, 3.5, 4, 5])
+    ax.set_yticks([.33, .4, .5, .6, .7, .85, 1, 1.2, 1.4, 1.66, 2, 2.5, 3, 3.5, 4])
     ax.yaxis.set_major_formatter(matplotlib.ticker.ScalarFormatter())
     dates = [datetime.strptime(d, "%Y-%m-%d") for d in field('date')]
     dates_ = matplotlib.dates.date2num(dates)
@@ -99,37 +171,87 @@ def plot_dates(model):
     return fig
 
 def plot_users(model, nameuser=lambda x: x):
-    field = lambda f: [x[f] for x in model['users']]
-
+    users = sorted(model['users'], key=lambda x: x['skill'])
+    field = lambda f: [x[f] for x in users]
     fig = matplotlib.figure.Figure(figsize=(8.5, 11))
     ax = fig.add_subplot(1, 1, 1)
     ax.set_title("Crossword Skill of User")
-    ax.errorbar(field('skill'), range(len(model['users'])), xerr=(field('skill_25'), field('skill_75')), fmt='o')
-    ax.set_yticks(range(len(model['users'])))
+    ax.errorbar(field('skill'), range(len(users)), xerr=(field('skill_25'), field('skill_75')), fmt='o')
+    ax.set_yticks(range(len(users)))
     ax.set_yticklabels(map(nameuser, field('uid')))
     ax.set_xscale('log')
-    ax.set_xticks([.4, .5, .6, .7, .85, 1, 1.2, 1.4, 1.66, 2, 2.5, 3, 4, 5])
+    ax.set_xticks([.33, .4, .5, .6, .7, .85, 1, 1.2, 1.4, 1.66, 2, 2.5, 3, 4])
     ax.xaxis.set_major_formatter(matplotlib.ticker.ScalarFormatter())
     return fig
 
-def plot_rates(model, nameuser=lambda x: x):
-    field = lambda f: [x[f] for x in model['users']]
-
-    fig = matplotlib.figure.Figure(figsize=(8.5, 11))
+def plot_rdates(data, model):
+    fig = matplotlib.figure.Figure(figsize=(11, 8.5))
     ax = fig.add_subplot(1, 1, 1)
-    ax.set_title("Improvement per Crossword")
-    ax.errorbar(field('rate'), range(len(model['users'])), xerr=(field('rate_25'), field('rate_75')), fmt='o')
-    ax.set_yticks(range(len(model['users'])))
-    ax.set_yticklabels(map(nameuser, field('uid')))
+    ax.xaxis_date(None)
+    pts = sorted([(d, r) for d, r in zip(data['dates'], residuals(data, model)) if d >= '2017'])
+    dates = [datetime.strptime(d, "%Y-%m-%d") for d, r in pts]
+    dates_ = matplotlib.dates.date2num(dates)
+    ax.plot(dates_, [r for d, r in pts], 'o')
+    yhat = savgol_filter([r for d, r in pts], 101, 1)
+    ax.plot(dates_, yhat, 'red')
+    ax.plot(dates_, [ 0 for n, r in pts ], 'black')
     return fig
 
-def plots(model, nameuser=lambda x: x):
+def plot_rnth(data, model):
+    nths = nth(data['uids'], data['dates'], data['ts'])
+    fig = matplotlib.figure.Figure(figsize=(11, 8.5))
+    ax = fig.add_subplot(1, 1, 1)
+    pts = sorted([(d, r) for d, r in zip(nths, residuals(data, model))])
+    ax.plot([d for d, r in pts], [r for d, r in pts], 'o')
+    yhat = savgol_filter([r for d, r in pts], 101, 1)
+    ax.plot([d for d, r in pts], yhat, 'red')
+    ax.plot([d for d, r in pts], [ 0 for n, r in pts ], 'black')
+    return fig
+
+
+def plots(data, model, nameuser=lambda x: x):
     agg.FigureCanvasAgg(plot_dates(model)).print_figure("dates.pdf")
     agg.FigureCanvasAgg(plot_users(model, nameuser=nameuser)).print_figure("users.pdf")
-    agg.FigureCanvasAgg(plot_rates(model, nameuser=nameuser)).print_figure("rates.pdf")
+    agg.FigureCanvasAgg(plot_rdates(data, model)).print_figure("res-dates.pdf")
+    agg.FigureCanvasAgg(plot_rnth(data, model)).print_figure("res-nth.pdf")
+
+def lookup_user(model, uid):
+    return [u for u in model["users"] if u["uid"] == uid][0]
+
+def judge_time(data, model, day, todays, person, time):
+    from math import log, exp
+    is_sat = datetime.strptime(day, "%Y-%m-%d").strftime("%w") == '6'
+
+    nths = {u: data["uids"].count(u) for u in todays}
+    ynth = data["uids"].count(person)
+
+    csecs = [log(secs)
+             - log(model["time"])
+             - log(lookup_user(model, user)["skill"])
+             - log(model["satmult"] if is_sat else 1)
+             - model['bgain'] * exp(-nths[user] / model['bdecay']) \
+             for user, secs in todays.items()]
+
+    difficulty = sum(csecs) / len(csecs)
+    ysecs = log(time) - log(model["time"]) - log(lookup_user(model, person)["skill"]) \
+        - log(model["satmult"] if is_sat else 1) - difficulty \
+        - model['bgain'] * exp(-ynth / model['bdecay'])
+    return ysecs / model["sigma"]
+        
+
+TEST = {
+    "U0GRSVAJU": 32,  # -0.96
+    "U0G3G2L9L": 35,  # -0.40
+    "U0G3HALFR": 36,  # -2.14
+    "U0G3FKDSS": 47,  # -1.13
+    "U57492YFJ": 100, # +1.50
+    "U0G3RR3EF": 101, # +1.45
+    "U8D4CK7NC": 113, # +0.37
+    "U0G6V794M": 136, # +1.31
+}
 
 DATA = data()
 FIT = fit(DATA)
 MODEL = extract_model(FIT)
 summarize(MODEL)
-plots(MODEL)
+plots(DATA, MODEL)

--- a/model.py
+++ b/model.py
@@ -314,8 +314,8 @@ def print_judgement(model, todays, date=None):
         print("    \"{}\": {:>3}, # {:+.2f}".format(u, t, d))
     print("}")
 
-DATA = data()
-FIT = fit(DATA)
-MODEL = extract_model(DATA, FIT)
-summarize(MODEL)
-plots(DATA, MODEL)
+if __name__ == "__main__":
+    DATA = data()
+    FIT = fit(DATA)
+    MODEL = extract_model(DATA, FIT)
+    save(MODEL)

--- a/model.py
+++ b/model.py
@@ -14,7 +14,7 @@ def unindex(l, i):
 
 def data():
     with sqlite3.connect("crossbot.db") as cursor:
-         uids, dates, dows, secs = zip(*cursor.execute("select userid, date, strftime('%w', date), seconds from mini_crossword_time where seconds >= 0"))
+         uids, dates, dows, secs = zip(*cursor.execute("select userid, date, strftime('%w', date), seconds from mini_crossword_time"))
          return { 'uids': uids, 'dates': dates, 'dows': dows, 'secs': secs }
 
 def ago(uids, dates):

--- a/model.py
+++ b/model.py
@@ -69,6 +69,9 @@ def summarize(fm, userdict=USERS):
     dates = [datetime.strptime(d, "%Y-%m-%d") for d, t in out]
     dates_ = matplotlib.dates.date2num(dates)
     ax.errorbar(dates_, pi(0, pi(1, out)), yerr=(pi(1, pi(1, out)), pi(2, pi(1, out))), fmt='o')
+    from scipy.signal import savgol_filter
+    yhat = savgol_filter(pi(0, pi(1, out)), 51, 3)
+    ax.plot(dates_, yhat, 'red')
     import matplotlib.backends.backend_agg as agg
     agg.FigureCanvasAgg(fig).print_figure("dates.pdf")
 

--- a/model.py
+++ b/model.py
@@ -238,16 +238,30 @@ def judge_time(data, model, day, todays, person, time):
         - model['bgain'] * exp(-ynth / model['bdecay'])
     return ysecs / model["sigma"]
         
+def print_judgement(data, model, todays):
+    judgements = { u: (t, judge_time(data, model, datetime.today().strftime("%Y-%m-%d"), TEST, u, t)) for u, t in todays.items() }
+    print("TEST = {")
+    for u, (t, d) in sorted(judgements.items(), key=lambda x: x[1][0]):
+        print("    \"{}\": {:>3}, # {:+.2f}".format(u, t, d))
+    print("}")
 
 TEST = {
-    "U0GRSVAJU": 32,  # -0.96
-    "U0G3G2L9L": 35,  # -0.40
-    "U0G3HALFR": 36,  # -2.14
-    "U0G3FKDSS": 47,  # -1.13
-    "U57492YFJ": 100, # +1.50
-    "U0G3RR3EF": 101, # +1.45
-    "U8D4CK7NC": 113, # +0.37
-    "U0G6V794M": 136, # +1.31
+    "U0WAPTL1Z":  22, # -0.29
+    "U0GG6DCCA":  22, # -0.80 James
+    "U6MKDAX2P":  29, # -0.14
+    "U0GRSVAJU":  32, # -0.79
+    "U2A6M3L10":  34, # -0.32
+    "U0G3G2L9L":  35, # -0.25
+    "U0G3HALFR":  36, # -1.97 Zach
+    "U1UKHF7FC":  45, # -0.23
+    "U0G3FKDSS":  47, # -0.98 Pavel
+    "U0N95LQQ6":  47, # -0.10
+    "U0GP7RWM8":  54, # -0.60
+    "U0GUBRDNE":  62, # +0.80
+    "U57492YFJ": 100, # +1.78
+    "U0G3RR3EF": 101, # +1.63
+    "U8D4CK7NC": 113, # +0.67
+    "U0G6V794M": 136, # +1.60
 }
 
 DATA = data()

--- a/model.py
+++ b/model.py
@@ -4,6 +4,8 @@ import pystan
 import sqlite3
 from datetime import datetime, timedelta
 import matplotlib, matplotlib.dates, matplotlib.figure, matplotlib.ticker
+from scipy.signal import savgol_filter
+import matplotlib.backends.backend_agg as agg
 
 def index(l):
     x = list(sorted(set(l)))
@@ -47,65 +49,87 @@ def drange(data):
 def pi(n, l):
     return map(lambda x: x[n], l)
 
-USERS = {}
-
-def summarize(fm, userdict=USERS):
+def extract_model(fm):
     params = fm.extract(['avg_time', 'avg_sat', 'avg_skill', 'avg_date', 'skill_dev', 'date_dev', 'sigma', 'improvement_rate'])
-    print("Dates")
-    out = []
+    
+    dates = []
     for i, multiplier in enumerate(params["avg_date"].transpose()):
         date = unindex(DATA['dates'], i + 1)
-        mult = drange(multiplier * 100)
-        if int(date[:4]) >= 2017: out.append((date, mult))
-        print("{:>10}: {: 6.1f} ({: 6.1f} {:+.1f})".format(date, mult[0], -mult[1], mult[2]))
+        mult_mean, mult_25, mult_75 = drange(multiplier)
+        dates.append({'date': date, 'difficulty': mult_mean, 'difficulty_25': mult_25, 'difficulty_75': mult_75})
+
+    users = []
+    for i, (multiplier, rate) in enumerate(zip(params["avg_skill"].transpose(), params["improvement_rate"].transpose())):
+        uid = unindex(DATA['uids'], i + 1)
+        mult_mean, mult_25, mult_75 = drange(multiplier)
+        rate_mean, rate_25, rate_75 = drange(rate)
+        users.append({ 'uid': uid, 'skill': mult_mean, 'skill_25': mult_25, 'skill_75': mult_75,
+                       'rate': rate_mean, 'rate_25': rate_25, 'rate_75': rate_75 })
+
+    time_mean, time_25, time_75 = drange(params['avg_time'])
+    satmult_mean, satmult_25, satmult_75 = drange(params['avg_sat'])
+    return { 'dates': dates, 'users': users, 'time': time_mean, 'time_25': time_25, 'time_75': time_75,
+             'satmult': satmult_mean, 'satmult_25': satmult_25, 'satmult_75': satmult_75,
+             'skill_dev': params['skill_dev'].mean(), 'date_dev': params['date_dev'].mean(), 'sigma': params['sigma'].mean(),
+    }
+
+def summarize(model, nameuser=lambda x: x):
+    for date in model['dates']:
+        print("{0[date]:>10}: {0[difficulty]: 6.3f} (-{0[difficulty_25]: 4.3f} {0[difficulty_75]:=+.3f})".format(date))
     print("")
+
+    for user in sorted(model['users'], key=lambda x: x['skill']):
+        name = nameuser(user['uid'])
+        print("{0:>20}: {1[skill]: 6.3f} (-{1[skill_25]: 4.3f} {1[skill_75]:=+6.3f}) {1[rate]:=+9.05f} t".format(name, user))
+
+def plot_dates(model):
+    field = lambda f: [x[f] for x in model['dates'] if x['date'][:4] >= '2017']
 
     fig = matplotlib.figure.Figure(figsize=(11, 8.5))
     ax = fig.add_subplot(1, 1, 1)
     ax.xaxis_date(None)
     ax.set_yscale('log')
-    ax.set_yticks([40, 50, 60, 75, 100, 133, 166, 200, 250, 300, 350, 400, 500])
+    ax.set_yticks([.4, .5, .6, .7, .85, 1, 1.2, 1.4, 1.66, 2, 2.5, 3, 3.5, 4, 5])
     ax.yaxis.set_major_formatter(matplotlib.ticker.ScalarFormatter())
-    dates = [datetime.strptime(d, "%Y-%m-%d") for d, t in out]
+    dates = [datetime.strptime(d, "%Y-%m-%d") for d in field('date')]
     dates_ = matplotlib.dates.date2num(dates)
-    ax.errorbar(dates_, pi(0, pi(1, out)), yerr=(pi(1, pi(1, out)), pi(2, pi(1, out))), fmt='o')
-    from scipy.signal import savgol_filter
-    yhat = savgol_filter(pi(0, pi(1, out)), 51, 3)
+    ax.errorbar(dates_, field('difficulty'), yerr=(field('difficulty_25'), field('difficulty_75')), fmt='o')
+    yhat = savgol_filter(field('difficulty'), 51, 3)
     ax.plot(dates_, yhat, 'red')
-    import matplotlib.backends.backend_agg as agg
-    agg.FigureCanvasAgg(fig).print_figure("dates.pdf")
+    return fig
 
-    print("Users")
-    out = []
-    for i, (multiplier, rate) in enumerate(zip(params["avg_skill"].transpose(), params["improvement_rate"].transpose())):
-        uid = unindex(DATA['uids'], i + 1)
-        user = USERS.get(uid, uid)
-        mult = drange(multiplier * 100)
-        growth = drange(rate * 100)
-        out.append((user, mult, growth))
-    out.sort(key=lambda x: x[1])
-    for uid, skill, rate in out:
-        print("{:>20}: {: 6.1f} ({: 6.1f} {:+6.1f}) {:=+7.03f} t".format(uid, skill[0], -skill[1], skill[2], rate[0]))
+def plot_users(model, nameuser=lambda x: x):
+    field = lambda f: [x[f] for x in model['users']]
 
     fig = matplotlib.figure.Figure(figsize=(8.5, 11))
     ax = fig.add_subplot(1, 1, 1)
     ax.set_title("Crossword Skill of User")
-    ax.errorbar(pi(0, pi(1, out)), range(len(out)), xerr=(pi(1, pi(1, out)), pi(2, pi(1, out))), fmt='o')
-    ax.set_yticks(range(len(out)))
-    ax.set_yticklabels(pi(0, out))
+    ax.errorbar(field('skill'), range(len(model['users'])), xerr=(field('skill_25'), field('skill_75')), fmt='o')
+    ax.set_yticks(range(len(model['users'])))
+    ax.set_yticklabels(map(nameuser, field('uid')))
     ax.set_xscale('log')
-    ax.set_xticks([50, 75, 100, 133, 200, 300, 500])
+    ax.set_xticks([.4, .5, .6, .7, .85, 1, 1.2, 1.4, 1.66, 2, 2.5, 3, 4, 5])
     ax.xaxis.set_major_formatter(matplotlib.ticker.ScalarFormatter())
-    agg.FigureCanvasAgg(fig).print_figure("users.pdf")
+    return fig
+
+def plot_rates(model, nameuser=lambda x: x):
+    field = lambda f: [x[f] for x in model['users']]
 
     fig = matplotlib.figure.Figure(figsize=(8.5, 11))
     ax = fig.add_subplot(1, 1, 1)
     ax.set_title("Improvement per Crossword")
-    ax.errorbar(pi(0, pi(2, out)), range(len(out)), xerr=(pi(1, pi(2, out)), pi(2, pi(2, out))), fmt='o')
-    ax.set_yticks(range(len(out)))
-    ax.set_yticklabels(pi(0, out))
-    agg.FigureCanvasAgg(fig).print_figure("rate.pdf")
+    ax.errorbar(field('rate'), range(len(model['users'])), xerr=(field('rate_25'), field('rate_75')), fmt='o')
+    ax.set_yticks(range(len(model['users'])))
+    ax.set_yticklabels(map(nameuser, field('uid')))
+    return fig
+
+def plots(model, nameuser=lambda x: x):
+    agg.FigureCanvasAgg(plot_dates(model)).print_figure("dates.pdf")
+    agg.FigureCanvasAgg(plot_users(model, nameuser=nameuser)).print_figure("users.pdf")
+    agg.FigureCanvasAgg(plot_rates(model, nameuser=nameuser)).print_figure("rates.pdf")
 
 DATA = data()
 FIT = fit(DATA)
-summarize(FIT)
+MODEL = extract_model(FIT)
+summarize(MODEL)
+plots(MODEL)

--- a/model.py
+++ b/model.py
@@ -1,0 +1,108 @@
+from __future__ import print_function
+
+import pystan
+import sqlite3
+from datetime import datetime, timedelta
+import matplotlib, matplotlib.dates, matplotlib.figure, matplotlib.ticker
+
+def index(l):
+    x = list(sorted(set(l)))
+    return [x.index(i) + 1 for i in l]
+
+def unindex(l, i):
+    return list(sorted(set(l)))[i - 1]
+
+def data():
+    with sqlite3.connect("crossbot.db") as cursor:
+         uids, dates, dows, secs = zip(*cursor.execute("select userid, date, strftime('%w', date), seconds from mini_crossword_time where seconds >= 0"))
+         return { 'uids': uids, 'dates': dates, 'dows': dows, 'secs': secs }
+
+def ago(uids, dates):
+    uid_dates = { the_uid: sorted([date for uid, date in zip(uids, dates) if uid == the_uid])
+                 for the_uid in set(uids)}
+    return [ len(uid_dates[uid]) - uid_dates[uid].index(date) for uid, date in zip(uids, dates) ]
+
+def munge_data(uids, dates, dows, secs):
+    return {
+        'uids': index(uids),
+        'dates': index(dates),
+        'ago': map(float, ago(uids, dates)),
+        'dows': [int(dow) + 1 for dow in dows],
+        'secs': secs,
+        'Us': len(set(uids)),
+        'Ss': len(secs),
+        'Ds': len(set(dates)),
+    }
+
+def fit(data):
+    sm = pystan.StanModel(file="crossbot.stan")
+    fm = sm.sampling(data=munge_data(**data), pars=['avg_time', 'avg_sat', 'avg_skill', 'avg_date', 'skill_dev', 'date_dev', 'sigma', 'improvement_rate'], iter=1000, chains=4)
+    return fm
+
+def drange(data):
+    data.sort()
+    mu = data.mean()
+    return mu, mu - data[len(data) // 4], data[len(data) * 3 // 4] - mu
+
+def pi(n, l):
+    return map(lambda x: x[n], l)
+
+USERS = {}
+
+def summarize(fm, userdict=USERS):
+    params = fm.extract(['avg_time', 'avg_sat', 'avg_skill', 'avg_date', 'skill_dev', 'date_dev', 'sigma', 'improvement_rate'])
+    print("Dates")
+    out = []
+    for i, multiplier in enumerate(params["avg_date"].transpose()):
+        date = unindex(DATA['dates'], i + 1)
+        mult = drange(multiplier * 100)
+        if int(date[:4]) >= 2017: out.append((date, mult))
+        print("{:>10}: {: 6.1f} ({: 6.1f} {:+.1f})".format(date, mult[0], -mult[1], mult[2]))
+    print("")
+
+    fig = matplotlib.figure.Figure(figsize=(11, 8.5))
+    ax = fig.add_subplot(1, 1, 1)
+    ax.xaxis_date(None)
+    ax.set_yscale('log')
+    ax.set_yticks([40, 50, 60, 75, 100, 133, 166, 200, 250, 300, 350, 400, 500])
+    ax.yaxis.set_major_formatter(matplotlib.ticker.ScalarFormatter())
+    dates = [datetime.strptime(d, "%Y-%m-%d") for d, t in out]
+    dates_ = matplotlib.dates.date2num(dates)
+    ax.errorbar(dates_, pi(0, pi(1, out)), yerr=(pi(1, pi(1, out)), pi(2, pi(1, out))), fmt='o')
+    import matplotlib.backends.backend_agg as agg
+    agg.FigureCanvasAgg(fig).print_figure("dates.pdf")
+
+    print("Users")
+    out = []
+    for i, (multiplier, rate) in enumerate(zip(params["avg_skill"].transpose(), params["improvement_rate"].transpose())):
+        uid = unindex(DATA['uids'], i + 1)
+        user = USERS.get(uid, uid)
+        mult = drange(multiplier * 100)
+        growth = drange(rate * 100)
+        out.append((user, mult, growth))
+    out.sort(key=lambda x: x[1])
+    for uid, skill, rate in out:
+        print("{:>20}: {: 6.1f} ({: 6.1f} {:+6.1f}) {:=+7.03f} t".format(uid, skill[0], -skill[1], skill[2], rate[0]))
+
+    fig = matplotlib.figure.Figure(figsize=(8.5, 11))
+    ax = fig.add_subplot(1, 1, 1)
+    ax.set_title("Crossword Skill of User")
+    ax.errorbar(pi(0, pi(1, out)), range(len(out)), xerr=(pi(1, pi(1, out)), pi(2, pi(1, out))), fmt='o')
+    ax.set_yticks(range(len(out)))
+    ax.set_yticklabels(pi(0, out))
+    ax.set_xscale('log')
+    ax.set_xticks([50, 75, 100, 133, 200, 300, 500])
+    ax.xaxis.set_major_formatter(matplotlib.ticker.ScalarFormatter())
+    agg.FigureCanvasAgg(fig).print_figure("users.pdf")
+
+    fig = matplotlib.figure.Figure(figsize=(8.5, 11))
+    ax = fig.add_subplot(1, 1, 1)
+    ax.set_title("Improvement per Crossword")
+    ax.errorbar(pi(0, pi(2, out)), range(len(out)), xerr=(pi(1, pi(2, out)), pi(2, pi(2, out))), fmt='o')
+    ax.set_yticks(range(len(out)))
+    ax.set_yticklabels(pi(0, out))
+    agg.FigureCanvasAgg(fig).print_figure("rate.pdf")
+
+DATA = data()
+FIT = fit(DATA)
+summarize(FIT)

--- a/scripts/init_db.sql
+++ b/scripts/init_db.sql
@@ -34,3 +34,11 @@ query_shorthands(
   timestamp TEXT NOT NULL,
   UNIQUE(name)
 );
+
+CREATE TABLE IF NOT EXISTS model (
+  userid TEXT NOT NULL,
+  date INTEGER NOT NULL,
+  prediction INTEGER NOT NULL,
+  residual REAL NOT NULL
+  UNIQUE(userid, date)
+);

--- a/scripts/init_db.sql
+++ b/scripts/init_db.sql
@@ -35,10 +35,11 @@ query_shorthands(
   UNIQUE(name)
 );
 
-CREATE TABLE IF NOT EXISTS model (
+CREATE TABLE IF NOT EXISTS
+mini_crossword_model(
   userid TEXT NOT NULL,
   date INTEGER NOT NULL,
   prediction INTEGER NOT NULL,
-  residual REAL NOT NULL
+  residual REAL NOT NULL,
   UNIQUE(userid, date)
 );


### PR DESCRIPTION
I'm continuing to work on the model, but this first version models every player's log-time on the mini crossword as normally distributed with three factors influencing the mean:
- The day's difficulty, including a bump for Saturdays
- The player's skill
- A beginner handicap
The model uses Stan to learn its parameters and can generate tables, plots, and predictions from those parameters.

This pull request commits the model but does not yet hook it up to the larger Crossbot infrastructure. However, it adds a SQL table, `mini_crossword_model`, and fills that table (plus a variety of tables starting with `model_`) with the model parameters; these tables could be queried by users. In the future, these tables could be built upon to add Crossbot features.

*To use*
First, run the `init_db.sql` script to add the new table. Then, if PyStan is installed, simply run `python model.py`, which will take roughly 15 minutes. When it completes, the model parameters and predictions have all been updated.