### PR TITLE
add private confirmation for add commands

### DIFF
--- a/crossbot/commands/add.py
+++ b/crossbot/commands/add.py
@@ -44,6 +44,9 @@ def add(client, request):
 
             con.execute(query, (request.userid, args.date, args.time, datetime.now()))
 
+            request.reply('Added {} for {}'.format(args.time, args.date),
+                          direct=True)
+
         except sqlite3.IntegrityError:
             query = '''
             SELECT seconds


### PR DESCRIPTION
This is a small patch preparing for adding a "missed" pseudo date.  It echos back to the user the time and date for a successful update to the database.