### PR TITLE
Adding a JavaScript plotting frontend

### DIFF
--- a/crossbot/static/crossbot/js/plot.js
+++ b/crossbot/static/crossbot/js/plot.js
@@ -1,0 +1,271 @@
+// Globals
+const TIME_MODEL_NAME_MAP = {
+  'minicrossword': "Mini Crossword",
+  'crossword': "Crossword",
+  'easysudoku': "Easy Sudoku",
+}
+
+//adapted from https://stackoverflow.com/questions/48719873/how-to-get-median-and-quartiles-percentiles-of-an-array-in-javascript-or-php
+//adapted from https://blog.poettner.de/2011/06/09/simple-statistics-with-php/
+Array.prototype.quartile = function(q) {
+  var data = this.slice();
+  data.sort(); // TODO: fix sorting here and everywhere else, use function
+  var pos = ((data.length) - 1) * q;
+  var base = Math.floor(pos);
+  var rest = pos - base;
+  if( (data[base+1]!==undefined) ) {
+    return data[base] + rest * (data[base+1] - data[base]);
+  } else {
+    return data[base];
+  }
+}
+
+Array.prototype.quartile_75 = function() {
+  return this.quartile(0.75);
+}
+Array.prototype.quartile_50 = function() {
+  return this.quartile(0.50);
+}
+Array.prototype.quartile_25 = function() {
+  return this.quartile(0.25);
+}
+Array.prototype.median = function() {
+  return this.quartile_50();
+}
+
+Array.prototype.sum = function() {
+   return this.reduce(function(a, b) { return a + b; }, 0);
+}
+
+Array.prototype.average = function() {
+  if (this.length == 0) {
+    return 0;
+  }
+  return this.sum() / this.length;
+}
+
+Array.prototype.stdev = function() {
+   var mean = this.average();
+   return Math.sqrt(this.map(x => Math.pow(x - mean, 2)).average());
+}
+
+// function setDefaultDates() {
+//   var d = new Date();
+
+//   function toVal(date) {
+//     return date.toISOString().split('T')[0];
+//   }
+
+//   $('#plot-settings input[name="end-date"]').val(toVal(d));
+//   d.setDate(d.getDate() - 10);
+//   $('#plot-settings input[name="start-date"]').val(toVal(d));
+// }
+
+function plotData(data) {
+  var times = data.times;
+
+  // Normalize the data if necessary
+  if($('#plot-settings input[name="plot-mode"][value="normalized"]').is(':checked')) {
+    times = normalizeTimes(data.times);
+  }
+
+  const today = new Date();
+  const one_week_ago = new Date(today);
+  one_week_ago.setDate(one_week_ago.getDate() - 7);
+  var end = data['end'];
+  if (new Date(end) > today) {
+    end = today;
+  }
+
+  // First, compile the times into user data
+  var userDataMap = {};
+  window.userDataMap = userDataMap;
+  for (var time of times) {
+    // Discard future times
+    if (new Date(time.date) > new Date(end)) {
+      continue;
+    }
+
+    if (!(time.user in userDataMap)) {
+      userDataMap[time.user] = {
+        type: 'scattergl',
+        name: time.user,
+        mode: 'lines+markers',
+        connectgaps: false,
+        x: [],
+        y: [],
+      }
+    } else {
+      // Push enough nulls to bring us up to date
+      // TODO: I think this breaks on DST (Mar 11)
+      var u = userDataMap[time.user];
+      var prev = new Date(u.x[u.x.length - 1]);
+      prev.setDate(prev.getDate() + 1)
+      var next = new Date(time.date);
+      if (prev < next) {
+        u.x.push(null);
+        u.y.push(null);
+      }
+    }
+    var u = userDataMap[time.user];
+    u.x.push(time.date);
+    u.y.push(time.seconds);
+  }
+
+  var userData = [];
+  window.userData = userData;
+  for (var user in userDataMap) {
+    userData.push(userDataMap[user]);
+  }
+
+
+
+  var layout = {
+    title: TIME_MODEL_NAME_MAP[data['timemodel']],
+    xaxis: {
+      title: 'Date',
+      range: [one_week_ago, today],
+      type: 'date',
+      zeroline: false,
+      fixedrange: true,
+      rangeselector: {buttons: [
+        {
+          count: 7,
+          label: '1w',
+          step: 'day',
+          stepmode: 'backward'
+        },
+        {
+          count: 1,
+          label: '1m',
+          step: 'month',
+          stepmode: 'backward'
+        },
+        {
+          count: 1,
+          label: '1y',
+          step: 'year',
+          stepmode: 'backward'
+        }
+      ]},
+      rangeslider: {range: [data['start'], today]},
+      type: 'date'
+    },
+    yaxis: {
+      title: 'Time (s)',
+      autorange: true,
+      fixedrange: true,
+    },
+    showlegend: true,
+  };
+
+  Plotly.newPlot('chart', userData, layout);
+}
+
+
+function normalizeTimes(times) {
+  const timesByDate = {};
+  for (var time of times) {
+    if (!(time.date in timesByDate)) {
+      timesByDate[time.date] = {};
+    }
+    timesByDate[time.date][time.user] = time.seconds;
+  }
+
+  const sortedDates = Object.keys(timesByDate).sort();
+
+  const MAX_SCORE = 1.5;
+  const FAILURE_PENALTY = -2
+
+  function mkScore(mean, t, stdev) {
+    if (t < 0) {
+      return FAILURE_PENALTY;
+    }
+    if (stdev == 0) {
+      return 0;
+    }
+
+    var score = (mean - t) / stdev;
+    if (score < -MAX_SCORE) {
+      return -MAX_SCORE;
+    }
+    if (score > MAX_SCORE) {
+      return MAX_SCORE;
+    }
+    return score;
+  }
+
+  var scoresForDate = {};
+  for (var date in timesByDate) {
+    var times = Object.values(timesByDate[date]);
+    var worstTime = Math.max(...times);
+
+    // make failures 1 minute worse than the worst time
+    times = times.map(function(t) {
+      if (t >= 0) {
+        return t;
+      } else {
+        return worstTime + 60;
+      }
+    });
+
+    var q1 = times.quartile_25();
+    var q3 = times.quartile_75();
+    var stdev = times.stdev();
+    var o1 = q1 - stdev;
+    var o3 = q3 - stdev;
+
+    times = times.filter(t => t >= o1 && t <= o3);
+    var mean = times.average();
+    var stdev = times.stdev();
+
+    scoresForDate[date] = {};
+    for (user in timesByDate[date]) {
+      scoresForDate[date][user] = mkScore(mean, timesByDate[date][user], stdev);
+    }
+  }
+
+  const NEW_SCORE_WEIGHT = 1 - $('#plot-settings input[name="smoothing-factor"]').val();
+  const running = {};
+  const weightedScores = []; // simple list of objects
+
+  for (var date of sortedDates) {
+    for (var user in scoresForDate[date]) {
+      var score = scoresForDate[date][user];
+
+      var oldScore = score;
+      if (user in running) {
+        oldScore = running[user];
+      }
+
+      var newScore = score * NEW_SCORE_WEIGHT + oldScore * (1 - NEW_SCORE_WEIGHT);
+      running[user] = newScore;
+
+      weightedScores.push({
+        user: user,
+        date: date,
+        seconds: newScore,
+      });
+    }
+  }
+
+  return weightedScores;
+}
+
+function getData() {
+  var url = '/rest-api/times/'
+
+  var timeModel = $('#plot-settings input[name="time-model"]:checked').val();
+  if (timeModel != undefined) {
+    url += timeModel + '/';
+  }
+
+  $.get(url, plotData);
+}
+
+$(function() {
+  getData();
+  $("#plot-settings").on("change", ":input", function() {
+    getData();
+  });
+});

--- a/crossbot/templates/crossbot/plot.html
+++ b/crossbot/templates/crossbot/plot.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% load staticfiles %}
+
+{% block content %}
+<form id="plot-settings">
+    <input type="radio" checked="checked" name="time-model" value="minicrossword">Mini Crossword
+    <input type="radio" name="time-model" value="crossword">Crossword
+    <input type="radio" name="time-model" value="easysudoku">Easy Sudoku
+
+    <br>
+
+    <input type="radio" checked="checked" name="plot-mode" value="normalized">Normalized
+    <input type="radio" name="plot-mode" value="raw">Raw Times
+    <input type="radio" name="plot-mode" value="streaks">Completion Streaks
+    <input type="radio" name="plot-mode" value="win-streaks">Win Streaks
+
+    <br>
+
+    <input type="radio" checked="checked" name="scale-mode" value="log">Log
+    <input type="radio" name="scale-mode" value="linear">Linear
+
+    <br>
+
+    Smoothing factor:
+    <input type="number" min="0" max="0.95" value="0.7" step="0.05" name="smoothing-factor">
+</form>
+
+<div id="chart"></div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+<script src="{% static "crossbot/js/plot.js" %}"></script>
+{% endblock %}

--- a/crossbot/urls.py
+++ b/crossbot/urls.py
@@ -1,23 +1,20 @@
-import datetime
-
 from django.urls import path
-from django.http import HttpResponse
 from django.views.generic.base import TemplateView
 from django.contrib.auth.decorators import login_required
 
 from . import views
 
 
-@login_required
-def private(request):
-    html = '<html><body>You are logged in!<br><a href="/logout/">Logout.</a></body></html>'
-    return HttpResponse(html)
-
-
 urlpatterns = [
     path('slack/', views.slash_command, name='slash_command'),
     path('api-event/', views.event, name='event'),
-    path('private/', private),
+    path('rest-api/times/<time_model>/', views.times_rest_api),
+    path('rest-api/times/', views.times_rest_api),
+    path(
+        'plot/',
+        login_required(
+            TemplateView.as_view(template_name='crossbot/plot.html')),
+        name='plot'),
     path(
         '',
         TemplateView.as_view(template_name='crossbot/index.html'),

--- a/crossbot/urls.py
+++ b/crossbot/urls.py
@@ -4,7 +4,6 @@ from django.contrib.auth.decorators import login_required
 
 from . import views
 
-
 urlpatterns = [
     path('slack/', views.slash_command, name='slash_command'),
     path('api-event/', views.event, name='event'),

--- a/crossbot/views.py
+++ b/crossbot/views.py
@@ -14,7 +14,6 @@ import settings
 from .slack import handle_slash_command
 from .models import MiniCrosswordTime, CrosswordTime, EasySudokuTime
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -86,6 +85,7 @@ TIME_MODELS = {
     'easysudoku': EasySudokuTime
 }
 
+
 @login_required
 @gzip_page
 @cache_control(max_age=3600)
@@ -101,16 +101,19 @@ def times_rest_api(request, time_model='minicrossword'):
     # if 'start' in request.GET:
     #     start_date = datetime.datetime.strptime(request.GET['start'], '%Y-%m-%d').date()
 
-    times = (TIME_MODELS[time_model].objects
-             .order_by('date')
-             .select_related('user'))
+    times = (TIME_MODELS[time_model].objects.order_by('date').select_related(
+        'user'))
 
     return JsonResponse({
         'times': [{
             'user': str(t.user),
             'date': t.date,
-            'seconds': t.seconds} for t in times],
-        'timemodel': time_model,
-        'start': times[0].date,
-        'end': times[len(times)-1].date,
-        })
+            'seconds': t.seconds
+        } for t in times],
+        'timemodel':
+        time_model,
+        'start':
+        times[0].date,
+        'end':
+        times[len(times) - 1].date,
+    })

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,14 +20,14 @@
 </head>
 <body>
     <nav class="navbar navbar-dark sticky-top bg-dark flex-md-nowrap p-0">
-      <a class="navbar-brand col-sm-3 col-md-2 mr-0" href="#">Crossbot</a>
+      <div class="navbar-brand col-sm-3 col-md-2 mr-0">Crossbot</div>
       <ul class="navbar-nav px-3">
         <li class="nav-item text-nowrap">
           {% block login_logout %}
             {% if user.is_authenticated %}
-              <a class="nav-link" href="/logout/">Log out</a>
+              <a class="nav-link" href="{% url 'logout' %}">Log out</a>
             {% else %}
-              <a class="nav-link" href="/login/">Log in</a>
+              <a class="nav-link" href="{% url 'login' %}">Log in</a>
             {% endif %}
           {% endblock %}
         </li>
@@ -40,13 +40,13 @@
           <div class="sidebar-sticky">
             <ul class="nav flex-column">
               <li class="nav-item">
-                <a class="nav-link" href="/">
+                <a class="nav-link" href="{% url 'home' %}">
                   <i class="fa fa-home"></i> Home
                 </a>
               </li>
               <li class="nav-item">
-                <a class="nav-link" href="/private/">
-                  Private
+                <a class="nav-link" href="{% url 'plot' %}">
+                  <i class="fa fa-line-chart"></i> View Plots
                 </a>
               </li>
             </ul>

--- a/urls.py
+++ b/urls.py
@@ -19,6 +19,7 @@ from django.contrib import admin
 from django.contrib.auth.views import LoginView, LogoutView
 from django.urls import path, include
 
+
 urlpatterns = [
     path('admin/', admin.site.urls),
     path(settings.LOGIN_URL.lstrip('/'), LoginView.as_view(), name='login'),

--- a/urls.py
+++ b/urls.py
@@ -19,7 +19,6 @@ from django.contrib import admin
 from django.contrib.auth.views import LoginView, LogoutView
 from django.urls import path, include
 
-
 urlpatterns = [
     path('admin/', admin.site.urls),
     path(settings.LOGIN_URL.lstrip('/'), LoginView.as_view(), name='login'),


### PR DESCRIPTION
WIP

This commit adds a very simple view to return JSON blobs with times, as well as some javascript that uses plotly.js to make plots. Just run the development server and go to `/plot/`

AFAICT, we need to solve the following before shipping this:

- [x] @require_login for plot view and json api view
      Depends on users being able to make accounts and login
- [x] Cache results on the javascript side  
      My idea for this is basically to create a day -> result list dict and then make efficient queries for the right ranges
- [x] Limit size of range for query and handle the limit on the javascript side
- [ ] Add way to display completion streaks and win streaks
      This might require a better way of limiting the users we display
- [ ] Handle log/linear option
- [ ] Fix the weird issue with my normalization function

Nice things to have:
- [ ] Fix xtics to only display days, never times