### PR TITLE
New announcement formatting

### DIFF
--- a/crossbot/cron.py
+++ b/crossbot/cron.py
@@ -84,7 +84,7 @@ class MorningAnnouncement(CronJobBase):
 
     def do(self):
         now = timezone.now()
-        announce_data = MiniCrosswordTime.announcement_data(now - timedelta(1))
+        announce_data = MiniCrosswordTime.announcement_data(now)
         message = self.format_message(announce_data)
         # TODO dont hardcode
         channel = 'C58PXJTNU'

--- a/crossbot/cron.py
+++ b/crossbot/cron.py
@@ -16,7 +16,7 @@ class ReleaseAnnouncement(CronJobBase):
     code = 'crossbot.release_announcement'
 
     def should_run_now(self, time):
-        if time.isoweekday() in (6,7): # It's Saturday or Sunday
+        if time.isoweekday() in (6, 7):  # It's Saturday or Sunday
             return 14 <= time.hour <= 15
         else:
             return 18 <= time.hour <= 19
@@ -32,7 +32,8 @@ class ReleaseAnnouncement(CronJobBase):
         # now add the other winners
         also = ' also' if announce_data['streaks'] else ''
         if announce_data['winners_today']:
-            msgs.append(', '.join(announce_data['winners_today']) + also + ' won.')
+            msgs.append(', '.join(announce_data['winners_today']) + also +
+                        ' won.')
         if announce_data['winners_yesterday']:
             msgs.append(', '.join(announce_data['winners_yesterday']) + also +
                         ' won yesterday.')
@@ -41,17 +42,19 @@ class ReleaseAnnouncement(CronJobBase):
             msgs.append("{} : {}".format(game, announce_data['links'][game]))
 
         return '\n'.join(msgs)
-        
+
     def do(self):
         now = timezone.now()
         if self.should_run_now(now):
-            announce_data = MiniCrosswordTime.announcement_data(now - timedelta(1))
+            announce_data = MiniCrosswordTime.announcement_data(now -
+                                                                timedelta(1))
             message = self.format_message(announce_data)
             # TODO dont hardcode
             channel = 'C58PXJTNU'
             logger.info("Running announce")
             response = post_message(channel, text=message)
             logger.info(response)
+
 
 class MorningAnnouncement(CronJobBase):
     schedule = Schedule(run_at_times=['08:30'])
@@ -69,7 +72,8 @@ class MorningAnnouncement(CronJobBase):
         # now add the other winners
         also = ' also' if announce_data['streaks'] else ''
         if announce_data['winners_today']:
-            msgs.append(', '.join(announce_data['winners_today']) + also + ' is winning.')
+            msgs.append(', '.join(announce_data['winners_today']) + also +
+                        ' is winning.')
         if announce_data['winners_yesterday']:
             msgs.append(', '.join(announce_data['winners_yesterday']) + also +
                         ' won yesterday.')
@@ -79,7 +83,6 @@ class MorningAnnouncement(CronJobBase):
 
         return '\n'.join(msgs)
 
-    
     def do(self):
         now = timezone.now()
         announce_data = MiniCrosswordTime.announcement_data(now - timedelta(1))
@@ -89,4 +92,3 @@ class MorningAnnouncement(CronJobBase):
         logger.info("Running announce")
         response = post_message(channel, text=message)
         logger.info(response)
-        

--- a/crossbot/cron.py
+++ b/crossbot/cron.py
@@ -50,9 +50,9 @@ class ReleaseAnnouncement(CronJobBase):
             message = self.format_message(announce_data)
             # TODO dont hardcode
             channel = 'C58PXJTNU'
-            logger.info("Running announce")
             response = post_message(channel, text=message)
-            logger.info(response)
+            return "Ran release announcement at {}\n{}".format(now, message)
+        return "Did not run release announcement at {}".format(now)
 
 
 class MorningAnnouncement(CronJobBase):
@@ -88,6 +88,5 @@ class MorningAnnouncement(CronJobBase):
         message = self.format_message(announce_data)
         # TODO dont hardcode
         channel = 'C58PXJTNU'
-        logger.info("Running announce")
         response = post_message(channel, text=message)
-        logger.info(response)
+        return "Ran morning announcement at {}\n{}".format(now, message)

--- a/crossbot/cron.py
+++ b/crossbot/cron.py
@@ -46,8 +46,7 @@ class ReleaseAnnouncement(CronJobBase):
     def do(self):
         now = timezone.now()
         if self.should_run_now(now):
-            announce_data = MiniCrosswordTime.announcement_data(now -
-                                                                timedelta(1))
+            announce_data = MiniCrosswordTime.announcement_data(now)
             message = self.format_message(announce_data)
             # TODO dont hardcode
             channel = 'C58PXJTNU'

--- a/crossbot/cron.py
+++ b/crossbot/cron.py
@@ -1,6 +1,8 @@
 from django_cron import CronJobBase, Schedule
 from django.utils import timezone
 
+from datetime import timedelta
+
 from crossbot.models import MiniCrosswordTime
 from crossbot.slack.api import post_message
 
@@ -9,15 +11,82 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class Announce(CronJobBase):
-    schedule = Schedule(run_at_times=['08:30'])
-    code = 'crossbot.announce'
+class ReleaseAnnouncement(CronJobBase):
+    schedule = Schedule(run_at_times=['15:00', '19:00'])
+    code = 'crossbot.release_announcement'
 
+    def should_run_now(self, time):
+        if time.isoweekday() in (6,7): # It's Saturday or Sunday
+            return 14 <= time.hour <= 15
+        else:
+            return 18 <= time.hour <= 19
+
+    def format_message(self, announce_data):
+        msgs = ['Good evening crossworders!']
+        msgs += [
+            '{u} is on a {n}-day streak! {emoji}'.format(
+                u=u, n=len(streak), emoji=':fire:' * len(streak))
+            for u, streak in announce_data['streaks']
+        ]
+
+        # now add the other winners
+        also = ' also' if announce_data['streaks'] else ''
+        if announce_data['winners_today']:
+            msgs.append(', '.join(announce_data['winners_today']) + also + ' won.')
+        if announce_data['winners_yesterday']:
+            msgs.append(', '.join(announce_data['winners_yesterday']) + also +
+                        ' won yesterday.')
+        msgs.append("Play tomorrow's:")
+        for game in announce_data['links']:
+            msgs.append("{} : {}".format(game, announce_data['links'][game]))
+
+        return '\n'.join(msgs)
+        
     def do(self):
-        date = timezone.now().date()
-        msg = MiniCrosswordTime.announcement_message(date)
+        now = timezone.now()
+        if self.should_run_now(now):
+            announce_data = MiniCrosswordTime.announcement_data(now - timedelta(1))
+            message = self.format_message(announce_data)
+            # TODO dont hardcode
+            channel = 'C58PXJTNU'
+            logger.info("Running announce")
+            response = post_message(channel, text=message)
+            logger.info(response)
+
+class MorningAnnouncement(CronJobBase):
+    schedule = Schedule(run_at_times=['08:30'])
+    code = 'crossbot.morning_announcement'
+
+    def format_message(self, announce_data):
+        msgs = ['Good morning crossworders!']
+
+        msgs += [
+            '{u} is currently on a {n}-day streak! {emoji}'.format(
+                u=u, n=len(streak), emoji=':fire:' * len(streak))
+            for u, streak in announce_data['streaks']
+        ]
+
+        # now add the other winners
+        also = ' also' if announce_data['streaks'] else ''
+        if announce_data['winners_today']:
+            msgs.append(', '.join(announce_data['winners_today']) + also + ' is winning.')
+        if announce_data['winners_yesterday']:
+            msgs.append(', '.join(announce_data['winners_yesterday']) + also +
+                        ' won yesterday.')
+        msgs.append("Think you can beat them? Play today's:")
+        for game in announce_data['links']:
+            msgs.append("{} : {}".format(game, announce_data['links'][game]))
+
+        return '\n'.join(msgs)
+
+    
+    def do(self):
+        now = timezone.now()
+        announce_data = MiniCrosswordTime.announcement_data(now - timedelta(1))
+        message = self.format_message(announce_data)
         # TODO dont hardcode
         channel = 'C58PXJTNU'
         logger.info("Running announce")
-        response = post_message(channel, text=msg)
+        response = post_message(channel, text=message)
         logger.info(response)
+        

--- a/crossbot/cron.py
+++ b/crossbot/cron.py
@@ -52,7 +52,8 @@ class ReleaseAnnouncement(CronJobBase):
             channel = 'C58PXJTNU'
             response = post_message(channel, text=message)
             return "Ran release announcement at {}\n{}".format(now, message)
-        return "Did not run release announcement at {} (hour={})".format(now,now.hour)
+        return "Did not run release announcement at {} (hour={})".format(
+            now, now.hour)
 
 
 class MorningAnnouncement(CronJobBase):

--- a/crossbot/cron.py
+++ b/crossbot/cron.py
@@ -52,7 +52,7 @@ class ReleaseAnnouncement(CronJobBase):
             channel = 'C58PXJTNU'
             response = post_message(channel, text=message)
             return "Ran release announcement at {}\n{}".format(now, message)
-        return "Did not run release announcement at {}".format(now)
+        return "Did not run release announcement at {} (hour={})".format(now,now.hour)
 
 
 class MorningAnnouncement(CronJobBase):

--- a/crossbot/models.py
+++ b/crossbot/models.py
@@ -298,6 +298,34 @@ class CommonTime(models.Model):
         return result
 
     @classmethod
+    def announcement_data(cls, date):
+        streaks = [(u, s) for u, s in cls.current_win_streaks(date).items()
+                   if len(s) > 1]
+        # sort by streak length, descending
+        streaks.sort(key=lambda x: len(x[1]), reverse=True)
+        streakers = set(u for u, s in streaks)
+
+        # get the winners who were not included in the long streaks
+        winners1 = [
+            str(w.user) for w in cls.winners(date) if w.user not in streakers
+        ]
+        yest = date - datetime.timedelta(days=1)
+        winners2 = [
+            str(w.user) for w in cls.winners(yest) if w.user not in streakers
+        ]
+
+        games = {
+            "mini crossword": "https://www.nytimes.com/crosswords/game/mini",
+            "easy sudoku":
+            "https://www.nytimes.com/crosswords/game/sudoku/easy"
+        }
+
+        return {'streaks': streaks,
+                'winners_today': winners1,
+                'winners_yesterday': winners2,
+                'links': games}
+    
+    @classmethod
     # TODO: should this be in model?
     def announcement_message(cls, date):
 

--- a/crossbot/models.py
+++ b/crossbot/models.py
@@ -320,11 +320,13 @@ class CommonTime(models.Model):
             "https://www.nytimes.com/crosswords/game/sudoku/easy"
         }
 
-        return {'streaks': streaks,
-                'winners_today': winners1,
-                'winners_yesterday': winners2,
-                'links': games}
-    
+        return {
+            'streaks': streaks,
+            'winners_today': winners1,
+            'winners_yesterday': winners2,
+            'links': games
+        }
+
     @classmethod
     # TODO: should this be in model?
     def announcement_message(cls, date):

--- a/crossbot/tests.py
+++ b/crossbot/tests.py
@@ -24,7 +24,7 @@ from crossbot.models import (
     EasySudokuTime,
     QueryShorthand,
 )
-from crossbot.cron import ReleaseAnnouncement,MorningAnnouncement
+from crossbot.cron import ReleaseAnnouncement, MorningAnnouncement
 from crossbot.settings import CROSSBUCKS_PER_SOLVE
 
 
@@ -448,20 +448,23 @@ class AnnouncementTests(SlackTestCase):
         self.weekday_right_time = datetime(2018, 10, 25, 19, tzinfo=tz)
         self.weekend_wrong_time = datetime(2018, 10, 27, 19, tzinfo=tz)
         self.weekend_right_time = datetime(2018, 10, 27, 15, tzinfo=tz)
-    
+
     def test_release_announcement_should_run_now(self):
-        self.assertFalse(self.release_announcement.should_run_now(self.weekday_wrong_time))
-        self.assertTrue(self.release_announcement.should_run_now(self.weekday_right_time))
-        self.assertFalse(self.release_announcement.should_run_now(self.weekend_wrong_time))
-        self.assertTrue(self.release_announcement.should_run_now(self.weekend_right_time))
+        self.assertFalse(
+            self.release_announcement.should_run_now(self.weekday_wrong_time))
+        self.assertTrue(
+            self.release_announcement.should_run_now(self.weekday_right_time))
+        self.assertFalse(
+            self.release_announcement.should_run_now(self.weekend_wrong_time))
+        self.assertTrue(
+            self.release_announcement.should_run_now(self.weekend_right_time))
 
     def test_release_announcement_run(self):
-        with patch.object(timezone, 'now', return_value=self.weekday_right_time):
+        with patch.object(
+                timezone, 'now', return_value=self.weekday_right_time):
             self.release_announcement.do()
             self.assertEquals(len(self.messages), 1)
 
     def test_morning_announcement_run(self):
         self.morning_announcement.do()
         self.assertEquals(len(self.messages), 1)
-            
-

--- a/settings/base.py
+++ b/settings/base.py
@@ -191,7 +191,8 @@ warnings.filterwarnings(
 )
 
 CRON_CLASSES = [
-    "crossbot.cron.Announce",
+    "crossbot.cron.ReleaseAnnouncement",
+    "crossbot.cron.MorningAnnouncement",
 ]
 
 # OAuth setup


### PR DESCRIPTION
Do two announcements per crossword. Doesn't change the current formatting too
much. There's a lot of duplication between the two announcement methods; I think
this is fine, since we are likely to want to modify them independently. I've
left the old "cb announce" stuff in place for now, but we should probably have
it use the same announcement code we use here.