### PR TITLE
Add way to make slash command non-ephemeral

### DIFF
--- a/crossbot/commands/plot_wins.py
+++ b/crossbot/commands/plot_wins.py
@@ -18,6 +18,7 @@ import crossbot
 
 from crossbot.parser import date_fmt
 
+# TODO: why the hell is this here again???
 
 def init(client):
 

--- a/crossbot/commands/plot_wins.py
+++ b/crossbot/commands/plot_wins.py
@@ -20,6 +20,7 @@ from crossbot.parser import date_fmt
 
 # TODO: why the hell is this here again???
 
+
 def init(client):
 
     parser = client.parser.subparsers.add_parser('plot-wins', help='plot wins')

--- a/crossbot/cron.py
+++ b/crossbot/cron.py
@@ -54,7 +54,7 @@ class ReleaseAnnouncement(CronJobBase):
             message = self.format_message(announce_data)
             # TODO dont hardcode
             channel = 'C58PXJTNU'
-            response = post_message(channel, text=message)
+            response = post_message(channel, {'text': message})
             return "Ran release announcement at {}\n{}".format(now, message)
         return "Did not run release announcement at {} (hour={})".format(
             now, now.hour
@@ -98,5 +98,5 @@ class MorningAnnouncement(CronJobBase):
         message = self.format_message(announce_data)
         # TODO dont hardcode
         channel = 'C58PXJTNU'
-        response = post_message(channel, text=message)
+        response = post_message(channel, {'text': message})
         return "Ran morning announcement at {}\n{}".format(now, message)

--- a/crossbot/slack/api.py
+++ b/crossbot/slack/api.py
@@ -49,12 +49,27 @@ def slack_users():
     return _slack_api_ok('members', endpoint='users.list', method='GET')
 
 
-def post_message(channel, **kwargs):
-    kwargs['channel'] = channel
-    return _slack_api_ok('ts', endpoint='chat.postMessage', params=kwargs)
+def post_message(channel, json):
+    return _slack_api_ok(
+        'ts',
+        endpoint='chat.postMessage',
+        data=json,
+        headers={'Content-Type': 'application/json'},
+        params={'channel': channel}
+    )
 
 
 def post_response(response_url, json):
     # For some bizarre reason, response_url doesn't work the same as postMessage
     resp = _slack_api(base_url=response_url, data=json)
     return resp.text == 'ok'
+
+
+def react(emoji, channel, timestamp):
+    return _slack_api_ok(
+        'ok',
+        endpoint='reactions.add',
+        name=emoji,
+        channel=channel,
+        timestamp=timestamp
+    )

--- a/crossbot/slack/api.py
+++ b/crossbot/slack/api.py
@@ -15,7 +15,7 @@ def _slack_api(
     assert method in ['GET', 'POST']
 
     headers = headers if headers is not None else {}
-    headers['Authorization'] = 'Bearer ' + settings.SLACK_OAUTH_ACCESS_TOKEN
+    headers['Authorization'] = 'Bearer ' + settings.SLACK_OAUTH_BOT_ACCESS_TOKEN
 
     url = base_url if base_url is not None else SLACK_URL
     url += endpoint

--- a/crossbot/slack/api.py
+++ b/crossbot/slack/api.py
@@ -15,7 +15,8 @@ def _slack_api(
     assert method in ['GET', 'POST']
 
     headers = headers if headers is not None else {}
-    headers['Authorization'] = 'Bearer ' + settings.SLACK_OAUTH_BOT_ACCESS_TOKEN
+    headers['Authorization'
+            ] = 'Bearer ' + settings.SLACK_OAUTH_BOT_ACCESS_TOKEN
 
     url = base_url if base_url is not None else SLACK_URL
     url += endpoint

--- a/crossbot/slack/commands/add.py
+++ b/crossbot/slack/commands/add.py
@@ -77,9 +77,8 @@ def add(request):
         streak_messages = STREAKS.get(streak_count)
         if streak_messages:
             msg = choice(streak_messages).format(name=request.user)
-            response.attach(
-                ephemeral=False, color="#39C53D", text=msg + "  :achievement:"
-            )
+            response.attach(ephemeral=False, color="#39C53D", text=msg)
+            response.add_reaction('achievement', ephemeral=False)
 
     logger.debug(
         "%s has a streak of %s in %s", request.user, new_sc, args.table

--- a/crossbot/slack/commands/add.py
+++ b/crossbot/slack/commands/add.py
@@ -52,13 +52,14 @@ def add(request):
     response.add_text(
         "Submitted {} for {}".format(time.time_str(), request.args.date)
     )
-    response.attach(
-        ephemeral=False,
-        as_user=request.user,
-        text="*{} Added:* {}  {}  :{}:".format(
+    response.add_text(
+        "*{} Added:* {}  {}  :{}:".format(
             time.SHORT_NAME, time.date, time.time_str(), emj
-        )
+        ),
+        ephemeral=False
     )
+    # Impersonate the user for the non-ephemeral message
+    response.set_user(request.user, ephemeral=False)
 
     def get_streak_counts(streaks):
         for streak in streaks:

--- a/crossbot/slack/commands/add.py
+++ b/crossbot/slack/commands/add.py
@@ -53,13 +53,14 @@ def add(request):
         "Submitted {} for {}".format(time.time_str(), request.args.date)
     )
     response.add_text(
-        "*{} Added:* {}  {}  :{}:".format(
-            time.SHORT_NAME, time.date, time.time_str(), emj
+        "*{} Added:* {}  {}".format(
+            time.SHORT_NAME, time.date, time.time_str()
         ),
         ephemeral=False
     )
     # Impersonate the user for the non-ephemeral message
     response.set_user(request.user, ephemeral=False)
+    response.add_reaction(emj, ephemeral=False)
 
     def get_streak_counts(streaks):
         for streak in streaks:

--- a/crossbot/slack/commands/announce.py
+++ b/crossbot/slack/commands/announce.py
@@ -22,4 +22,5 @@ def announce(request):
     '''Report who won the previous day and if they're on a streak.
     Optionally takes a date.'''
     message = request.args.table.announcement_message(request.args.date)
-    return SlashCommandResponse(text=message)
+    return SlashCommandResponse(message,
+                                ephemeral=False, ephemeral_command=False)

--- a/crossbot/slack/commands/announce.py
+++ b/crossbot/slack/commands/announce.py
@@ -22,5 +22,6 @@ def announce(request):
     '''Report who won the previous day and if they're on a streak.
     Optionally takes a date.'''
     message = request.args.table.announcement_message(request.args.date)
-    return SlashCommandResponse(message,
-                                ephemeral=False, ephemeral_command=False)
+    return SlashCommandResponse(
+        message, ephemeral=False, ephemeral_command=False
+    )

--- a/crossbot/slack/commands/plot.py
+++ b/crossbot/slack/commands/plot.py
@@ -322,9 +322,10 @@ def plot(request):
         fig.savefig(f, format='png', bbox_inches='tight')
     plt.close(fig)
 
-    response = SlashCommandResponse()
+    response = SlashCommandResponse(ephemeral_command=False)
     response.attach(
-        pretext='plot',
+        ephemeral=False,
+        pretext='Plot',
         image_url=request.build_absolute_uri(MEDIA_URL + fname),
     )
 

--- a/crossbot/slack/commands/times.py
+++ b/crossbot/slack/commands/times.py
@@ -51,5 +51,6 @@ def times(request):
     else:
         message = '*Times for {}*\n'.format(date_str) + message
 
-    return SlashCommandResponse(message,
-                                ephemeral=False, ephemeral_command=False)
+    return SlashCommandResponse(
+        message, ephemeral=False, ephemeral_command=False
+    )

--- a/crossbot/slack/commands/times.py
+++ b/crossbot/slack/commands/times.py
@@ -51,4 +51,5 @@ def times(request):
     else:
         message = '*Times for {}*\n'.format(date_str) + message
 
-    return SlashCommandResponse(text=message)
+    return SlashCommandResponse(message,
+                                ephemeral=False, ephemeral_command=False)

--- a/crossbot/slack/handler.py
+++ b/crossbot/slack/handler.py
@@ -1,9 +1,11 @@
 import json
 
+from django.conf import settings
+
 from .parser import Parser, ParserException
 from . import commands
 from .message import SlashCommandRequest, Message
-from .api import post_response
+from .api import post_response, post_message, react
 
 PARSER = Parser()
 
@@ -29,31 +31,28 @@ def handle_slash_command(django_request):
 
         if response.ephemeral_message and response.direct_message:
             # Send ephemeral instead of returning it so it appears first
-            post_response(
-                request.response_url,
-                json.dumps(response.ephemeral_message.asdict())
-            )
+            _send_message(request, response.ephemeral_message)
 
             if response.ephemeral_message:
-                post_response(
-                    request.response_url,
-                    json.dumps(response.direct_message.asdict())
-                )
+                _send_message(request, response.direct_message)
                 return None
-            return response.direct_message.asdict()
+            return _send_message(
+                request, response.direct_message, should_return=True
+            )
 
         if response.ephemeral_message:
             # If there's only an ephemeral message, command is always ephemeral
-            return response.ephemeral_message.asdict()
+            return _send_message(
+                request, response.ephemeral_message, should_return=True
+            )
 
         if response.direct_message:
-            if response.ephemeral_command:
-                post_response(
-                    request.response_url,
-                    json.dumps(response.direct_message.asdict())
-                )
+            if response.ephemeral_message:
+                _send_message(request, response.direct_message)
                 return None
-            return response.direct_message.asdict()
+            return _send_message(
+                request, response.direct_message, should_return=True
+            )
 
         return None
 
@@ -61,3 +60,20 @@ def handle_slash_command(django_request):
         message = Message(ephemeral=True)
         message.text = str(exn)
         return message.asdict()
+
+
+def _send_message(request, message, should_return=False):
+    if not message.reactions or not _in_main_channel(request):
+        if should_return:
+            return message.asdict()
+        post_response(request.response_url, json.dumps(message.asdict()))
+        return None
+
+    timestamp = post_message(request.channel, json.dumps(message.asdict()))
+    for reaction in message.reactions:
+        react(reaction, request.channel, timestamp)
+    return None
+
+
+def _in_main_channel(request):
+    return request.channel == getattr(settings, 'CROSSBOT_MAIN_CHANNEL', None)

--- a/crossbot/slack/handler.py
+++ b/crossbot/slack/handler.py
@@ -53,6 +53,7 @@ def handle_slash_command(django_request):
             # TODO: what if we have to react to this message?
             #       we shouldn't return None then, should at least return with
             #       response_type: in_channel or something
+            #       (same for above)
             return _send_message(
                 request, response.direct_message, should_return=True
             )

--- a/crossbot/slack/handler.py
+++ b/crossbot/slack/handler.py
@@ -33,21 +33,27 @@ def handle_slash_command(django_request):
                 request.response_url,
                 json.dumps(response.ephemeral_message.asdict())
             )
-            post_response(
-                request.response_url,
-                json.dumps(response.direct_message.asdict())
-            )
-            return None
 
-        if response.direct_message:
-            post_response(
-                request.response_url,
-                json.dumps(response.direct_message.asdict())
-            )
-            return None
+            if response.ephemeral_message:
+                post_response(
+                    request.response_url,
+                    json.dumps(response.direct_message.asdict())
+                )
+                return None
+            return response.direct_message.asdict()
 
         if response.ephemeral_message:
+            # If there's only an ephemeral message, command is always ephemeral
             return response.ephemeral_message.asdict()
+
+        if response.direct_message:
+            if response.ephemeral_command:
+                post_response(
+                    request.response_url,
+                    json.dumps(response.direct_message.asdict())
+                )
+                return None
+            return response.direct_message.asdict()
 
         return None
 

--- a/crossbot/slack/handler.py
+++ b/crossbot/slack/handler.py
@@ -50,6 +50,9 @@ def handle_slash_command(django_request):
             if response.ephemeral_message:
                 _send_message(request, response.direct_message)
                 return None
+            # TODO: what if we have to react to this message?
+            #       we shouldn't return None then, should at least return with
+            #       response_type: in_channel or something
             return _send_message(
                 request, response.direct_message, should_return=True
             )

--- a/crossbot/slack/message.py
+++ b/crossbot/slack/message.py
@@ -47,6 +47,12 @@ class SlashCommandResponse:
         self.ephemeral_command = ephemeral_command
 
     # TODO: maybe use magic methods instead of these for convenience methods
+    def set_user(self, *args, ephemeral=True, **kwargs):
+        if ephemeral:
+            self.ephemeral_message.set_user(*args, **kwargs)
+        else:
+            self.direct_message.set_user(*args, **kwargs)
+
     def add_text(self, *args, ephemeral=True, **kwargs):
         if ephemeral:
             self.ephemeral_message.add_text(*args, **kwargs)
@@ -73,10 +79,20 @@ class SlashCommandResponse:
 
 
 class Message:
-    def __init__(self, text='', ephemeral=None):
+    def __init__(self, text='', user=None, ephemeral=None):
         self.text = text
         self.attachments = []
         self.ephemeral = ephemeral
+
+        self.username = None
+        self.icon_url = None
+
+        if user is not None:
+            self.set_user(user)
+
+    def set_user(self, user):
+        self.username = user.slack_fullname or user.slackname or None
+        self.icon_url = user.image_url or None
 
     def add_text(self, text, add_newline=True):
         """Adds text to the main message."""
@@ -115,6 +131,10 @@ class Message:
             message_dict['response_type'] = (
                 'ephemeral' if self.ephemeral else 'in_channel'
             )
+        if self.username is not None:
+            message_dict['username'] = self.username
+        if self.icon_url is not None:
+            message_dict['icon_url'] = self.icon_url
         return message_dict
 
 

--- a/crossbot/slack/message.py
+++ b/crossbot/slack/message.py
@@ -77,6 +77,12 @@ class SlashCommandResponse:
         else:
             self.direct_message.attach_image(*args, **kwargs)
 
+    def add_reaction(self, *args, ephemeral=True, **kwargs):
+        if ephemeral:
+            self.ephemeral_message.add_reaction(*args, **kwargs)
+        else:
+            self.direct_message.add_reaction(*args, **kwargs)
+
 
 class Message:
     def __init__(self, text='', user=None, ephemeral=None):
@@ -89,6 +95,9 @@ class Message:
 
         if user is not None:
             self.set_user(user)
+
+        # These reactions only get sent if the channel is CROSSBOT_MAIN_CHANNEL
+        self.reactions = []
 
     def set_user(self, user):
         self.username = user.slack_fullname or user.slackname or None
@@ -115,6 +124,9 @@ class Message:
         return self.attach(
             fallback="image: %s" % name, pretext=name, image_url=path
         )
+
+    def add_reaction(self, emoji):
+        self.reactions.append(emoji.strip(':'))
 
     def __bool__(self):
         return bool(self.text or self.attachments)

--- a/crossbot/slack/message.py
+++ b/crossbot/slack/message.py
@@ -126,7 +126,9 @@ class Message:
         )
 
     def add_reaction(self, emoji):
-        self.reactions.append(emoji.strip(':'))
+        emoji = emoji.strip(':')
+        if emoji not in self.reactions:
+            self.reactions.append(emoji)
 
     def __bool__(self):
         return bool(self.text or self.attachments)

--- a/crossbot/slack/message.py
+++ b/crossbot/slack/message.py
@@ -32,7 +32,9 @@ class SlashCommandRequest:
 class SlashCommandResponse:
     """Contains both an ephemeral and non-ephemeral message to send."""
 
-    def __init__(self, *args, ephemeral=True, ephemeral_command=True, **kwargs):
+    def __init__(
+            self, *args, ephemeral=True, ephemeral_command=True, **kwargs
+    ):
         """Initializes both messages, but sends all args to chosen one."""
         if ephemeral:
             self.ephemeral_message = Message(ephemeral=True, *args, **kwargs)

--- a/crossbot/slack/message.py
+++ b/crossbot/slack/message.py
@@ -7,8 +7,6 @@ from ..models import CBUser
 
 logger = logging.getLogger(__name__)
 
-# TODO: move this/rename file; "handler.py" is weird
-
 
 class SlashCommandRequest:
     def __init__(self, django_request, args=None):
@@ -34,10 +32,17 @@ class SlashCommandRequest:
 class SlashCommandResponse:
     """Contains both an ephemeral and non-ephemeral message to send."""
 
-    def __init__(self, *args, **kwargs):
-        """Initializes both messages, but sends all args to ephemeral one."""
-        self.ephemeral_message = Message(ephemeral=True, *args, **kwargs)
-        self.direct_message = Message(ephemeral=False)
+    def __init__(self, *args, ephemeral=True, ephemeral_command=True, **kwargs):
+        """Initializes both messages, but sends all args to chosen one."""
+        if ephemeral:
+            self.ephemeral_message = Message(ephemeral=True, *args, **kwargs)
+            self.direct_message = Message(ephemeral=False)
+        else:
+            self.ephemeral_message = Message(ephemeral=True)
+            self.direct_message = Message(ephemeral=False, *args, **kwargs)
+
+        # Whether or not the original slash command should be ephemeral
+        self.ephemeral_command = ephemeral_command
 
     # TODO: maybe use magic methods instead of these for convenience methods
     def add_text(self, *args, ephemeral=True, **kwargs):

--- a/crossbot/tests.py
+++ b/crossbot/tests.py
@@ -442,8 +442,9 @@ class SlackAppTests(SlackTestCase):
         self.slack_post('add :40 2018-08-01', who='bob')
 
         # check date parsing here too
-        response = self.slack_post('times 2018-8-1',
-                                   expected_response_type='in_channel')
+        response = self.slack_post(
+            'times 2018-8-1', expected_response_type='in_channel'
+        )
 
         lines = response['text'].split('\n')
 
@@ -476,8 +477,9 @@ class SlackAppTests(SlackTestCase):
         self.assertIn(':23', response['text'])
 
         # Ensure the time doesn't show up in the times list
-        response = self.slack_post(text='times 2018-08-01',
-                                   expected_response_type='in_channel')
+        response = self.slack_post(
+            text='times 2018-08-01', expected_response_type='in_channel'
+        )
         self.assertNotIn(':23', response['text'])
 
     @unittest.skipUnless(os.path.isfile('crossbot.db'), 'No existing db found')
@@ -552,8 +554,9 @@ class SlackAppTests(SlackTestCase):
         self.slack_post(text='add :10 2018-08-02')
         self.slack_post(text='add :10 2018-08-03')
         self.slack_post(text='add :10 2018-08-04')
-        response = self.slack_post(text='plot',
-                                   expected_response_type='in_channel')
+        response = self.slack_post(
+            text='plot', expected_response_type='in_channel'
+        )
         self.assertIn(
             settings.MEDIA_URL, response['attachments'][0]['image_url']
         )

--- a/crossbot/tests.py
+++ b/crossbot/tests.py
@@ -442,7 +442,8 @@ class SlackAppTests(SlackTestCase):
         self.slack_post('add :40 2018-08-01', who='bob')
 
         # check date parsing here too
-        response = self.slack_post('times 2018-8-1')
+        response = self.slack_post('times 2018-8-1',
+                                   expected_response_type='in_channel')
 
         lines = response['text'].split('\n')
 
@@ -475,7 +476,8 @@ class SlackAppTests(SlackTestCase):
         self.assertIn(':23', response['text'])
 
         # Ensure the time doesn't show up in the times list
-        response = self.slack_post(text='times 2018-08-01')
+        response = self.slack_post(text='times 2018-08-01',
+                                   expected_response_type='in_channel')
         self.assertNotIn(':23', response['text'])
 
     @unittest.skipUnless(os.path.isfile('crossbot.db'), 'No existing db found')
@@ -550,7 +552,8 @@ class SlackAppTests(SlackTestCase):
         self.slack_post(text='add :10 2018-08-02')
         self.slack_post(text='add :10 2018-08-03')
         self.slack_post(text='add :10 2018-08-04')
-        response = self.slack_post(text='plot')
+        response = self.slack_post(text='plot',
+                                   expected_response_type='in_channel')
         self.assertIn(
             settings.MEDIA_URL, response['attachments'][0]['image_url']
         )

--- a/crossbot/tests.py
+++ b/crossbot/tests.py
@@ -130,6 +130,7 @@ class SlackTestCase(MockedRequestTestCase):
 
         self.patch('settings.SLACK_SECRET_SIGNING_KEY', self.slack_sk)
         self.patch('settings.SLACK_OAUTH_ACCESS_TOKEN', 'oauth_token')
+        self.patch('settings.SLACK_OAUTH_BOT_ACCESS_TOKEN', 'bot_oauth_token')
 
     def patch(self, *args, **kwargs):
         patcher = patch(*args, **kwargs)
@@ -139,7 +140,9 @@ class SlackTestCase(MockedRequestTestCase):
 
     def check_headers(self, method, url, headers):
         if url.startswith(SLACK_URL):
-            self.assertEqual(headers['Authorization'], 'Bearer oauth_token')
+            self.assertEqual(
+                headers['Authorization'], 'Bearer bot_oauth_token'
+            )
 
     def _slack_reaction_add(self, method, url, headers, params, data):
         return MockResponse(json.dumps({'ok': True}), 200)

--- a/settings/dev.py
+++ b/settings/dev.py
@@ -14,3 +14,4 @@ SOCIAL_AUTH_SLACK_KEY = 'slack-client-id'
 SOCIAL_AUTH_SLACK_SECRET = 'slack-client-secret'
 
 CROSSBOT_SOCIAL_AUTH_SLACK_ALLOWED_TEAMS = [] # Insert team IDs here
+CROSSBOT_MAIN_CHANNEL = '' # #minicrossword channel ID


### PR DESCRIPTION
This adds a way to make the slash command non-ephemeral in the messages.py infrastructure, and the handler intelligently decides where to send each message based on that setting.

Times, announcements, and plots are now posted in-channel, and the slash command that sends them is non-ephemeral.