### PR TITLE
Update slack names and images from Cron job

### DIFF
--- a/crossbot/cron.py
+++ b/crossbot/cron.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from datetime import timedelta
 
 from crossbot.util import comma_and
-from crossbot.models import MiniCrosswordTime
+from crossbot.models import MiniCrosswordTime, CBUser
 from crossbot.slack.api import post_message
 import crossbot.predictor as predictor
 
@@ -127,3 +127,13 @@ class Predictor(CronJobBase):
         predictor.save(model)
         historic, dates, users, params = model
         return "Ran the predictor at {}".format(params.when_run)
+
+
+class SlacknameUpdater(CronJobBase):
+    schedule = Schedule(run_at_times=['2:00'])
+    code = 'crossbot.update_slacknames'
+
+    def do(self):
+        now = timezone.localtime()
+        CBUser.update_slacknames()
+        return "Updated slack_users at {}".format(now)

--- a/settings/base.py
+++ b/settings/base.py
@@ -199,6 +199,7 @@ CRON_CLASSES = [
     "crossbot.cron.ReleaseAnnouncement",
     "crossbot.cron.MorningAnnouncement",
     "crossbot.cron.Predictor",
+    "crossbot.cron.SlacknameUpdater"
 ]
 
 DJANGO_CRON_LOCK_BACKEND = "django_cron.backends.lock.file.FileLock"


### PR DESCRIPTION
I think there used to be an actual crontab that would run this, but it makes
more sense to do it using django-cron like the other scheduled tasks.

I haven't tested this at all.